### PR TITLE
Add double click select

### DIFF
--- a/source/Editor/Editor.cs
+++ b/source/Editor/Editor.cs
@@ -107,6 +107,9 @@ public class Editor : Scene {
 
         public static Vector2 World { get; internal set; }
         public static Vector2 WorldLast { get; internal set; }
+
+        public static DateTime LastClick { get; internal set; }
+        public static bool IsDoubleClick => MInput.Mouse.PressedLeftButton && DateTime.Now < Mouse.LastClick.AddMilliseconds(200);
     }
 
     public static Editor Instance { get; private set; }
@@ -373,6 +376,11 @@ public class Editor : Scene {
             if (MInput.Keyboard.Pressed(Keys.F) && CanTypeShortcut()) {
                 FancyRender = !FancyRender;
             }
+        }
+
+        // Double click 
+        if (MInput.Mouse.PressedLeftButton) {
+            Mouse.LastClick = DateTime.Now;
         }
     }
 


### PR DESCRIPTION
Add Double click to select all entities of the same type into the editor, this should work even if something is already selected.

Also adds "IsDoubleClick" as a field in Editor.Mouse