### PR TITLE
Add nine patch draw helper and core block plugin

### DIFF
--- a/source/Editor/Entities/Plugin_BounceBlock.cs
+++ b/source/Editor/Entities/Plugin_BounceBlock.cs
@@ -1,0 +1,45 @@
+﻿using Celeste;
+using Microsoft.Xna.Framework;
+using Monocle;
+using Snowberry.Editor.Entities.Util;
+
+namespace Snowberry.Editor.Entities;
+
+[Plugin("bounceBlock")]
+public class Plugin_BounceBlock : Entity {
+
+    public override int MinWidth => 24;
+    public override int MinHeight => 24;
+
+    private EditorNinePatch hotPatch;
+    private EditorNinePatch coldPatch;
+    private MTexture hotCrystal;
+    private MTexture coldCrystal;
+
+    [Option("notCoreMode")] public bool notCoreMode;
+
+    public Plugin_BounceBlock() {
+        hotPatch = new EditorNinePatch(GFX.Game["objects/bumpblocknew/fire00"]);
+        coldPatch = new EditorNinePatch(GFX.Game["objects/bumpblocknew/ice00"]);
+        hotCrystal = GFX.Game["objects/bumpblocknew/fire_center00"];
+        coldCrystal = GFX.Game["objects/bumpblocknew/ice_center00"];
+    }
+
+    public override void RenderBefore() {
+        base.RenderBefore();
+    }
+    public override void Render() {
+        base.Render();
+        if (notCoreMode) {
+            coldPatch.Draw(Position, Width, Height, Color.White);
+            coldCrystal.DrawCentered(Position + new Vector2(Width, Height) / 2);
+        } else {
+            hotPatch.Draw(Position, Width, Height, Color.White);
+            hotCrystal.DrawCentered(Position + new Vector2(Width, Height) / 2);
+        }
+    }
+
+    public static void AddPlacements() {
+        Placements.Create("Core Block", "BounceBlock", new() { ["notCoreMode"] = false });
+    }
+}

--- a/source/Editor/Entities/Util/EditorNinePatch.cs
+++ b/source/Editor/Entities/Util/EditorNinePatch.cs
@@ -9,41 +9,33 @@ namespace Snowberry.Editor.Entities.Util;
 
 public class EditorNinePatch {
 
+    private MTexture[,] nineSliceTexture;
 
-    private MTexture[,] nineSliceTextureCorners;
-    private List<MTexture> nineSliceTextureTop;
-    private List<MTexture> nineSliceTextureLeft;
-    private List<MTexture> nineSliceTextureRight;
-    private List<MTexture> nineSliceTextureBottom;
-    private MTexture[,] nineSliceTextureMiddle;
     public EditorNinePatch(MTexture mtexture) {
 
         int tileWidth = mtexture.Width/8;
         int tileHeight = mtexture.Height/8;
 
-        nineSliceTextureCorners = new MTexture[2, 2];
-        nineSliceTextureTop = new();
-        nineSliceTextureLeft = new();
-        nineSliceTextureRight = new();
-        nineSliceTextureBottom = new();
-        nineSliceTextureMiddle = new MTexture[tileWidth - 2, tileHeight - 2];
+        nineSliceTexture = new MTexture[tileWidth, tileHeight];
 
         for (int i = 0; i < 2; i++) {
             for (int j = 0; j < 2; j++) {
-                nineSliceTextureCorners[i, j] = mtexture.GetSubtexture(new Rectangle((i == 1 ? tileWidth - 1 : i) * 8, (j == 1 ? tileHeight - 1 : j) * 8, 8, 8));
+                int x = (i == 1 ? tileWidth - 1 : i);
+                int y = (j == 1 ? tileHeight - 1 : j);
+                nineSliceTexture[x, y] = mtexture.GetSubtexture(new Rectangle(x * 8, y * 8, 8, 8));
             }
         }
         for (int i = 1; i < tileWidth - 1; i++) {
-            nineSliceTextureTop.Add(mtexture.GetSubtexture(new Rectangle(i*8, 0, 8, 8)));
-            nineSliceTextureBottom.Add(mtexture.GetSubtexture(new Rectangle(i*8, (tileHeight - 1) * 8, 8, 8)));
+            nineSliceTexture[i, 0] = mtexture.GetSubtexture(new Rectangle(i*8, 0, 8, 8));
+            nineSliceTexture[i, tileHeight - 1] = mtexture.GetSubtexture(new Rectangle(i*8, (tileHeight - 1) * 8, 8, 8));
         }
         for (int j = 1; j < tileHeight - 1; j++) {
-            nineSliceTextureLeft.Add(mtexture.GetSubtexture(new Rectangle(0, j*8, 8, 8)));
-            nineSliceTextureRight.Add(mtexture.GetSubtexture(new Rectangle((tileWidth - 1) * 8, j * 8, 8, 8)));
+            nineSliceTexture[0, j] = mtexture.GetSubtexture(new Rectangle(0, j*8, 8, 8));
+            nineSliceTexture[tileWidth - 1, j] = mtexture.GetSubtexture(new Rectangle((tileWidth - 1) * 8, j * 8, 8, 8));
         }
         for (int k = 1; k < tileWidth - 1; k++) {
             for (int l = 1; l < tileHeight - 1; l++) {
-                nineSliceTextureMiddle[k-1, l-1] = mtexture.GetSubtexture(new Rectangle(k*8, l * 8, 8, 8));
+                nineSliceTexture[k, l] = mtexture.GetSubtexture(new Rectangle(k*8, l * 8, 8, 8));
             }
         }
     }
@@ -52,27 +44,32 @@ public class EditorNinePatch {
         int tileWidth = (int)(width / 8f);
         int tileHeight = (int)(height / 8f);
 
-        nineSliceTextureCorners[0, 0].Draw(pos + new Vector2(0f, 0f), Vector2.Zero, color);
-        nineSliceTextureCorners[1, 0].Draw(pos + new Vector2(width - 8f, 0f), Vector2.Zero, color);
-        nineSliceTextureCorners[0, 1].Draw(pos + new Vector2(0f, height - 8f), Vector2.Zero, color);
-        nineSliceTextureCorners[1, 1].Draw(pos + new Vector2(width - 8f, height - 8f), Vector2.Zero, color);
+        int rows = nineSliceTexture.GetLength(0);
+        int columns = nineSliceTexture.GetLength(1);
+
+        // nr => 1 - max (if nr >= 0)
+        static int moduloClamp(int nr, int max) {
+            return (nr % max) + 1;
+        };
+
+        nineSliceTexture[0, 0].Draw(pos + new Vector2(0f, 0f), Vector2.Zero, color);
+        nineSliceTexture[rows - 1, 0].Draw(pos + new Vector2(width - 8f, 0f), Vector2.Zero, color);
+        nineSliceTexture[0, columns - 1].Draw(pos + new Vector2(0f, height - 8f), Vector2.Zero, color);
+        nineSliceTexture[rows - 1, columns - 1].Draw(pos + new Vector2(width - 8f, height - 8f), Vector2.Zero, color);
 
         for (int i = 1; i < tileWidth - 1; i++) {
-            nineSliceTextureTop[(i - 1) % nineSliceTextureTop.Count].Draw(pos + new Vector2((float)(i * 8), 0f), Vector2.Zero, color);
-            nineSliceTextureBottom[(i - 1) % nineSliceTextureBottom.Count].Draw(pos + new Vector2((float)(i * 8), height - 8f), Vector2.Zero, color);
+            nineSliceTexture[moduloClamp(i - 1, rows - 1), 0].Draw(pos + new Vector2((float)(i * 8), 0f), Vector2.Zero, color);
+            nineSliceTexture[moduloClamp(i - 1, rows - 1), columns - 1].Draw(pos + new Vector2((float)(i * 8), height - 8f), Vector2.Zero, color);
         }
 
         for (int j = 1; j < tileHeight - 1; j++) {
-            nineSliceTextureLeft[(j - 1) % nineSliceTextureLeft.Count].Draw(pos + new Vector2(0f, (float)(j * 8)), Vector2.Zero, color);
-            nineSliceTextureRight[(j - 1) % nineSliceTextureRight.Count].Draw(pos + new Vector2(width - 8f, (float)(j * 8)), Vector2.Zero, color);
+            nineSliceTexture[0, moduloClamp(j - 1, columns - 1)].Draw(pos + new Vector2(0f, (float)(j * 8)), Vector2.Zero, color);
+            nineSliceTexture[rows - 1, moduloClamp(j - 1, columns - 1)].Draw(pos + new Vector2(width - 8f, (float)(j * 8)), Vector2.Zero, color);
         }
-
-        int kMax = nineSliceTextureMiddle.GetLength(0);
-        int lMax = nineSliceTextureMiddle.GetLength(1);
 
         for (int k = 1; k < tileWidth - 1; k++) {
             for (int l = 1; l < tileHeight - 1; l++) {
-                nineSliceTextureMiddle[(k - 1) % kMax, (l - 1) % lMax].Draw(pos + new Vector2((float)k, (float)l) * 8f, Vector2.Zero, color);
+                nineSliceTexture[moduloClamp(k - 1, rows - 2), moduloClamp(l - 1, rows - 2)].Draw(pos + new Vector2((float)k, (float)l) * 8f, Vector2.Zero, color);
             }
         }
     }

--- a/source/Editor/Entities/Util/EditorNinePatch.cs
+++ b/source/Editor/Entities/Util/EditorNinePatch.cs
@@ -58,13 +58,13 @@ public class EditorNinePatch {
         nineSliceTexture[rows - 1, columns - 1].Draw(pos + new Vector2(width - 8f, height - 8f), Vector2.Zero, color);
 
         for (int i = 1; i < tileWidth - 1; i++) {
-            nineSliceTexture[moduloClamp(i - 1, rows - 1), 0].Draw(pos + new Vector2((float)(i * 8), 0f), Vector2.Zero, color);
-            nineSliceTexture[moduloClamp(i - 1, rows - 1), columns - 1].Draw(pos + new Vector2((float)(i * 8), height - 8f), Vector2.Zero, color);
+            nineSliceTexture[moduloClamp(i - 1, rows - 2), 0].Draw(pos + new Vector2((float)(i * 8), 0f), Vector2.Zero, color);
+            nineSliceTexture[moduloClamp(i - 1, rows - 2), columns - 1].Draw(pos + new Vector2((float)(i * 8), height - 8f), Vector2.Zero, color);
         }
 
         for (int j = 1; j < tileHeight - 1; j++) {
-            nineSliceTexture[0, moduloClamp(j - 1, columns - 1)].Draw(pos + new Vector2(0f, (float)(j * 8)), Vector2.Zero, color);
-            nineSliceTexture[rows - 1, moduloClamp(j - 1, columns - 1)].Draw(pos + new Vector2(width - 8f, (float)(j * 8)), Vector2.Zero, color);
+            nineSliceTexture[0, moduloClamp(j - 1, columns - 2)].Draw(pos + new Vector2(0f, (float)(j * 8)), Vector2.Zero, color);
+            nineSliceTexture[rows - 1, moduloClamp(j - 1, columns - 2)].Draw(pos + new Vector2(width - 8f, (float)(j * 8)), Vector2.Zero, color);
         }
 
         for (int k = 1; k < tileWidth - 1; k++) {

--- a/source/Editor/Entities/Util/EditorNinePatch.cs
+++ b/source/Editor/Entities/Util/EditorNinePatch.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using Celeste.Mod.Helpers;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Monocle;
+
+namespace Snowberry.Editor.Entities.Util;
+
+public class EditorNinePatch {
+
+
+    private MTexture[,] nineSliceTextureCorners;
+    private List<MTexture> nineSliceTextureTop;
+    private List<MTexture> nineSliceTextureLeft;
+    private List<MTexture> nineSliceTextureRight;
+    private List<MTexture> nineSliceTextureBottom;
+    private MTexture[,] nineSliceTextureMiddle;
+    public EditorNinePatch(MTexture mtexture) {
+
+        int tileWidth = mtexture.Width/8;
+        int tileHeight = mtexture.Height/8;
+
+        nineSliceTextureCorners = new MTexture[2, 2];
+        nineSliceTextureTop = new();
+        nineSliceTextureLeft = new();
+        nineSliceTextureRight = new();
+        nineSliceTextureBottom = new();
+        nineSliceTextureMiddle = new MTexture[tileWidth - 2, tileHeight - 2];
+
+        for (int i = 0; i < 2; i++) {
+            for (int j = 0; j < 2; j++) {
+                nineSliceTextureCorners[i, j] = mtexture.GetSubtexture(new Rectangle((i == 1 ? tileWidth - 1 : i) * 8, (j == 1 ? tileHeight - 1 : j) * 8, 8, 8));
+            }
+        }
+        for (int i = 1; i < tileWidth - 1; i++) {
+            nineSliceTextureTop.Add(mtexture.GetSubtexture(new Rectangle(i*8, 0, 8, 8)));
+            nineSliceTextureBottom.Add(mtexture.GetSubtexture(new Rectangle(i*8, (tileHeight - 1) * 8, 8, 8)));
+        }
+        for (int j = 1; j < tileHeight - 1; j++) {
+            nineSliceTextureLeft.Add(mtexture.GetSubtexture(new Rectangle(0, j*8, 8, 8)));
+            nineSliceTextureRight.Add(mtexture.GetSubtexture(new Rectangle((tileWidth - 1) * 8, j * 8, 8, 8)));
+        }
+        for (int k = 1; k < tileWidth - 1; k++) {
+            for (int l = 1; l < tileHeight - 1; l++) {
+                nineSliceTextureMiddle[k-1, l-1] = mtexture.GetSubtexture(new Rectangle(k*8, l * 8, 8, 8));
+            }
+        }
+    }
+
+    public void Draw(Vector2 pos, int width, int height, Color color) {
+        int tileWidth = (int)(width / 8f);
+        int tileHeight = (int)(height / 8f);
+
+        nineSliceTextureCorners[0, 0].Draw(pos + new Vector2(0f, 0f), Vector2.Zero, color);
+        nineSliceTextureCorners[1, 0].Draw(pos + new Vector2(width - 8f, 0f), Vector2.Zero, color);
+        nineSliceTextureCorners[0, 1].Draw(pos + new Vector2(0f, height - 8f), Vector2.Zero, color);
+        nineSliceTextureCorners[1, 1].Draw(pos + new Vector2(width - 8f, height - 8f), Vector2.Zero, color);
+
+        for (int i = 1; i < tileWidth - 1; i++) {
+            nineSliceTextureTop[(i - 1) % nineSliceTextureTop.Count].Draw(pos + new Vector2((float)(i * 8), 0f), Vector2.Zero, color);
+            nineSliceTextureBottom[(i - 1) % nineSliceTextureBottom.Count].Draw(pos + new Vector2((float)(i * 8), height - 8f), Vector2.Zero, color);
+        }
+
+        for (int j = 1; j < tileHeight - 1; j++) {
+            nineSliceTextureLeft[(j - 1) % nineSliceTextureLeft.Count].Draw(pos + new Vector2(0f, (float)(j * 8)), Vector2.Zero, color);
+            nineSliceTextureRight[(j - 1) % nineSliceTextureRight.Count].Draw(pos + new Vector2(width - 8f, (float)(j * 8)), Vector2.Zero, color);
+        }
+
+        int kMax = nineSliceTextureMiddle.GetLength(0);
+        int lMax = nineSliceTextureMiddle.GetLength(1);
+
+        for (int k = 1; k < tileWidth - 1; k++) {
+            for (int l = 1; l < tileHeight - 1; l++) {
+                nineSliceTextureMiddle[(k - 1) % kMax, (l - 1) % lMax].Draw(pos + new Vector2((float)k, (float)l) * 8f, Vector2.Zero, color);
+            }
+        }
+    }
+}

--- a/source/Snowberry.csproj
+++ b/source/Snowberry.csproj
@@ -29,7 +29,7 @@
       <Private>false</Private>
     </Reference>
     <Reference Include="System.ValueTuple">
-      <HintPath>..\..\..\System.ValueTuple.dll</HintPath>
+      <HintPath>$(CelestePrefix)\System.ValueTuple.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Creates a nine patch draw function for any width/height (divisible by eight) out of a texture of at least 3x3 (using 8x8 tiles).
If bigger than 3x3 repeats textures using modulo.
Invisible lines on the side could break this rendering correctly

Made simple core block plugin to test it