### PR TITLE
fix crash when trying to edit tiles when there is no selected room

### DIFF
--- a/source/Editor/Tools/TileBrushTool.cs
+++ b/source/Editor/Tools/TileBrushTool.cs
@@ -193,9 +193,10 @@ public class TileBrushTool : Tool {
 
         if (canClick && (MInput.Mouse.PressedLeftButton || (middlePan && MInput.Mouse.PressedRightButton))) {
             if (mode != TileBrushMode.Eyedropper) {
-                isPainting = true;
-                if (Editor.SelectedRoom != null)
+                if (Editor.SelectedRoom != null) {
+                    isPainting = true;
                     UndoRedo.BeginAction("edit tiles", Editor.SelectedRoom.SnapshotTiles());
+                }
             } else
                 HandleEyedropper(left);
         } else if (MInput.Mouse.ReleasedLeftButton || (middlePan && MInput.Mouse.ReleasedRightButton)) {


### PR DESCRIPTION
this happens since it can start painting without making an undo/redo action, meaning that when painting is done the action is ended (but never started).
from a glance at the other usages of `CompleteAction`, i think this is the only problematic one.