### PR TITLE
Fix bucket tool performance in large rooms

### DIFF
--- a/source/Editor/Tools/TileBrushTool.cs
+++ b/source/Editor/Tools/TileBrushTool.cs
@@ -256,7 +256,9 @@ public class TileBrushTool : Tool {
                         char origTile = Editor.SelectedRoom.GetTile(fg, new Vector2((x + Editor.SelectedRoom.X) * 8, (y + Editor.SelectedRoom.Y) * 8));
 
                         bool inside(int cx, int cy) {
-                            return (cx >= 0 && cy >= 0 && cx < Editor.SelectedRoom.Width && cy < Editor.SelectedRoom.Height) && Editor.SelectedRoom.GetTile(fg, new Vector2((cx + Editor.SelectedRoom.X) * 8, (cy + Editor.SelectedRoom.Y) * 8)) == origTile;
+                            return (cx >= 0 && cy >= 0 && cx < Editor.SelectedRoom.Width && cy < Editor.SelectedRoom.Height)
+                                   && Editor.SelectedRoom.GetTile(fg, new Vector2((cx + Editor.SelectedRoom.X) * 8, (cy + Editor.SelectedRoom.Y) * 8)) == origTile
+                                   && !holoSetTiles[cx, cy];
                         }
 
                         Queue<Point> toCheck = new Queue<Point>();


### PR DESCRIPTION
`inside` should return false for tiles that have been checked by the flood fill algo