### PR TITLE
make snowberry's ui adapt reasonably well to non-1080p screen sizes

### DIFF
--- a/source/Editor/Editor.cs
+++ b/source/Editor/Editor.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -693,6 +693,8 @@ public class Editor : UIScene {
     }
 
     protected override void OnScreenResized() {
+        Camera?.SetViewChanged();
+
         if(Toolbar != null) { // TODO: remove when the main menu becomes its own scene
             Toolbar.Width = UI.Width;
             ToolPanel.Position = new Vector2(UI.Width - ToolPanel.Width, Toolbar.Height);

--- a/source/Mouse.cs
+++ b/source/Mouse.cs
@@ -5,12 +5,15 @@ using Monocle;
 namespace Snowberry;
 
 public static class Mouse {
+    public static bool InBounds { get; internal set; }
     public static Vector2 Screen { get; internal set; }
     public static Vector2 ScreenLast { get; internal set; }
 
     public static Vector2 World { get; internal set; }
     public static Vector2 WorldLast { get; internal set; }
 
+    public static bool IsFocused { get; internal set; }
+
     public static DateTime LastClick { get; internal set; }
-    public static bool IsDoubleClick => MInput.Mouse.PressedLeftButton && DateTime.Now < LastClick.AddMilliseconds(200);
+    public static bool IsDoubleClick => IsFocused && MInput.Mouse.PressedLeftButton && DateTime.Now < LastClick.AddMilliseconds(200);
 }

--- a/source/Snowberry.cs
+++ b/source/Snowberry.cs
@@ -45,6 +45,8 @@ public sealed class Snowberry : EverestModule {
             typeof(Editor.Editor).GetMethod("HookSessionGetAreaData", BindingFlags.Static | BindingFlags.NonPublic)
         );
 
+        On.Monocle.Engine.UpdateView += UpdateView;
+
         On.Celeste.Editor.MapEditor.ctor += UsePlaytestMap;
         On.Celeste.MapData.StartLevel += DontCrashOnEmptyPlaytestLevel;
         On.Celeste.LevelEnter.Routine += DontEnterPlaytestMap;
@@ -69,6 +71,8 @@ public sealed class Snowberry : EverestModule {
     public override void Unload() {
         hook_MapData_orig_Load?.Dispose();
         hook_Session_get_MapData?.Dispose();
+
+        On.Monocle.Engine.UpdateView -= UpdateView;
 
         On.Celeste.Editor.MapEditor.ctor -= UsePlaytestMap;
         On.Celeste.MapData.StartLevel -= DontCrashOnEmptyPlaytestLevel;
@@ -179,6 +183,13 @@ public sealed class Snowberry : EverestModule {
     public static void Log(LogLevel level, string message) => Logger.Log(level, "Snowberry", message);
 
     public static void LogInfo(string message) => Log(LogLevel.Info, message);
+
+    public static void UpdateView(On.Monocle.Engine.orig_UpdateView orig, Engine self) {
+        orig(self);
+
+        if (Engine.Scene is Editor.Editor e)
+            e.Camera?.SetViewChanged();
+    }
 
     private static void UsePlaytestMap(On.Celeste.Editor.MapEditor.orig_ctor orig, Celeste.Editor.MapEditor self, AreaKey area, bool reloadMapData) {
         orig(self, area, reloadMapData);

--- a/source/Snowberry.cs
+++ b/source/Snowberry.cs
@@ -45,8 +45,6 @@ public sealed class Snowberry : EverestModule {
             typeof(Editor.Editor).GetMethod("HookSessionGetAreaData", BindingFlags.Static | BindingFlags.NonPublic)
         );
 
-        On.Monocle.Engine.UpdateView += UpdateView;
-
         On.Celeste.Editor.MapEditor.ctor += UsePlaytestMap;
         On.Celeste.MapData.StartLevel += DontCrashOnEmptyPlaytestLevel;
         On.Celeste.LevelEnter.Routine += DontEnterPlaytestMap;
@@ -71,8 +69,6 @@ public sealed class Snowberry : EverestModule {
     public override void Unload() {
         hook_MapData_orig_Load?.Dispose();
         hook_Session_get_MapData?.Dispose();
-
-        On.Monocle.Engine.UpdateView -= UpdateView;
 
         On.Celeste.Editor.MapEditor.ctor -= UsePlaytestMap;
         On.Celeste.MapData.StartLevel -= DontCrashOnEmptyPlaytestLevel;
@@ -183,13 +179,6 @@ public sealed class Snowberry : EverestModule {
     public static void Log(LogLevel level, string message) => Logger.Log(level, "Snowberry", message);
 
     public static void LogInfo(string message) => Log(LogLevel.Info, message);
-
-    public static void UpdateView(On.Monocle.Engine.orig_UpdateView orig, Engine self) {
-        orig(self);
-
-        if (Engine.Scene is Editor.Editor e)
-            e.Camera?.SetViewChanged();
-    }
 
     private static void UsePlaytestMap(On.Celeste.Editor.MapEditor.orig_ctor orig, Celeste.Editor.MapEditor self, AreaKey area, bool reloadMapData) {
         orig(self, area, reloadMapData);


### PR DESCRIPTION
- fix matrix maths, so the various camera matrices are always correct regardless of screen size
- add letterboxing, so snowberry stays in the middle of the screen and doesn't try to draw in the black bars
- show the native mouse pointer when hovering over a letterbox bar, since snowberry's cursor doesn't draw there
- also, ignore inputs for 2 frames when the focus changes, so that spurious clicks/scrolls (due to MInput jank) are ignored
  - this behaviour might not be the best way to approach it, and i'd be happy to rework it if an alternative would be better
- also, show the native mouse pointer (not the snowberry one) when the celeste window is unfocused, so that it's not confusing that clicks-to-focus aren't treated as clicks-to-interact