### PR TITLE
make 1x zoom actually 1x, by decoupling rendering from the (1080p) Engine.ScreenMatrix

### DIFF
--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -261,6 +261,9 @@ SNOWBERRY_SNOWBERRY={# d12626}Snowberry{#}
     SNOWBERRY_SETTINGS_MIDDLE_CLICK_PAN=        Middle Click to Pan
     SNOWBERRY_SETTINGS_MIDDLE_CLICK_PAN_SUB=    Whether to use middle click to pan and right click for alternate placements,{n}or right click to pan and alt-left-click for alternate placements.
     
+    SNOWBERRY_SETTINGS_PAN_WRAPS_MOUSE=        Use Mouse Wrapping
+    SNOWBERRY_SETTINGS_PAN_WRAPS_MOUSE_SUB=    Whether the mouse pointer should wrap around the editor when panning,{n}to avoid hitting the edge of the monitor.
+    
     SNOWBERRY_SETTINGS_FANCY_RENDER=            Fancy Rendering
     SNOWBERRY_SETTINGS_FANCY_RENDER_SUB=        Whether to display entities more accurately in-editor, such as spinners and dream blocks.
     

--- a/source/Mouse.cs
+++ b/source/Mouse.cs
@@ -12,6 +12,30 @@ public static class Mouse {
     public static Vector2 World { get; internal set; }
     public static Vector2 WorldLast { get; internal set; }
 
+    public static Vector2 PendingWarp { get; internal set; }
+    public static Vector2 ScreenAfterWarp {
+        get => Screen + PendingWarp;
+        set => PendingWarp = value - Screen;
+    }
+
+    public static Vector2 Warp(Vector2 screenPos) {
+        var delta = screenPos - Screen;
+        PendingWarp += delta;
+        return delta;
+    }
+
+    public static Vector2 Wrap(Rectangle screenRect, int padding = 5) {
+        if (screenRect.Width <= padding * 2 || screenRect.Height <= padding * 2)
+            return Vector2.Zero;
+
+        var dest = ScreenAfterWarp;
+
+        dest.X = Util.Wrap(dest.X, screenRect.Left + padding, screenRect.Right - padding);
+        dest.Y = Util.Wrap(dest.Y, screenRect.Top + padding, screenRect.Bottom - padding);
+
+        return Warp(dest);
+    }
+
     public static bool IsFocused { get; internal set; }
 
     public static DateTime LastClick { get; internal set; }

--- a/source/SnowberrySettings.cs
+++ b/source/SnowberrySettings.cs
@@ -8,6 +8,10 @@ public class SnowberrySettings : EverestModuleSettings {
     [SettingSubText("SNOWBERRY_SETTINGS_MIDDLE_CLICK_PAN_SUB")]
     public bool MiddleClickPan { get; set; } = true;
 
+    [SettingName("SNOWBERRY_SETTINGS_PAN_WRAPS_MOUSE")]
+    [SettingSubText("SNOWBERRY_SETTINGS_PAN_WRAPS_MOUSE_SUB")]
+    public bool PanWrapsMouse { get; set; } = false;
+
     [SettingName("SNOWBERRY_SETTINGS_FANCY_RENDER")]
     [SettingSubText("SNOWBERRY_SETTINGS_FANCY_RENDER_SUB")]
     public bool FancyRender { get; set; } = true;

--- a/source/UI/Menus/UIMainMenu.cs
+++ b/source/UI/Menus/UIMainMenu.cs
@@ -125,6 +125,11 @@ public class UIMainMenu : UIElement {
             Snowberry.Instance.SaveSettings();
         }));
         settingsOptions.AddBelow(new UILabel(Dialog.Clean("SNOWBERRY_SETTINGS_MIDDLE_CLICK_PAN_SUB")), descOffset);
+        settingsOptions.AddBelow(UIPluginOptionList.BoolOption(Dialog.Clean("SNOWBERRY_SETTINGS_PAN_WRAPS_MOUSE"), Snowberry.Settings.PanWrapsMouse, b => {
+            Snowberry.Settings.PanWrapsMouse = b;
+            Snowberry.Instance.SaveSettings();
+        }), settingsOffset);
+        settingsOptions.AddBelow(new UILabel(Dialog.Clean("SNOWBERRY_SETTINGS_PAN_WRAPS_MOUSE_SUB")), descOffset);
         settingsOptions.AddBelow(UIPluginOptionList.BoolOption(Dialog.Clean("SNOWBERRY_SETTINGS_FANCY_RENDER"), Snowberry.Settings.FancyRender, b => {
             Snowberry.Settings.FancyRender = b;
             Snowberry.Instance.SaveSettings();

--- a/source/UI/UIScene.cs
+++ b/source/UI/UIScene.cs
@@ -85,7 +85,7 @@ public abstract class UIScene : Scene {
         Mouse.InBounds = pos.X >= 0 && pos.X < Engine.ViewWidth
                       && pos.Y >= 0 && pos.Y < Engine.ViewHeight;
         Mouse.Screen = pos / UiScale;
-        Mouse.World = CalculateMouseWorld(m);
+        Mouse.World = ScreenToWorld(Mouse.Screen);
 
         wasActive = isActive;
         isActive = Engine.Instance.IsActive && !Engine.Commands.Open && Mouse.InBounds;
@@ -100,6 +100,17 @@ public abstract class UIScene : Scene {
 
         if (Mouse.IsFocused && MInput.Mouse.PressedLeftButton)
             Mouse.LastClick = DateTime.Now;
+
+        if (Mouse.PendingWarp != Vector2.Zero)
+            WarpMouse();
+    }
+
+    protected virtual void WarpMouse() {
+        var destScreen = Mouse.ScreenAfterWarp;
+        var destWindow = (destScreen * UiScale) + new Vector2(Engine.Viewport.X, Engine.Viewport.Y);
+
+        Microsoft.Xna.Framework.Input.Mouse.SetPosition((int)destWindow.X, (int)destWindow.Y);
+        Mouse.PendingWarp = Vector2.Zero;
     }
 
     public override void Render() {
@@ -158,7 +169,8 @@ public abstract class UIScene : Scene {
     protected virtual void PostBeginContent() {}
     protected virtual void RenderContent() {}
     protected virtual void UpdateContent() {}
-    protected virtual Vector2 CalculateMouseWorld(MouseState m) => new Vector2(m.X, m.Y) / UiScale;
+    protected virtual Vector2 ScreenToWorld(Vector2 pos) => pos;
+    protected virtual Vector2 WorldToScreen(Vector2 pos) => pos;
     protected virtual void SuggestCursor(ref MTexture texture, ref Vector2 justify) {}
     protected virtual void OnScreenResized() {}
     protected virtual bool ShouldShowUi() => true;

--- a/source/Util.cs
+++ b/source/Util.cs
@@ -135,4 +135,7 @@ public static class Util {
         var pairs = dict.Where(pair => pair.Value.ToString().Equals(value.ToString()));
         return pairs.Any() ? pairs.FirstOrDefault().Key : fallback;
     }
+
+    public static float Mod(float x, float m) => (x % m + m) % m;
+    public static float Wrap(float val, float min, float max) => Mod(val - min, max - min) + min;
 }


### PR DESCRIPTION
currently, the editor buffer size and scaling take into account `Engine.ScreenMatrix`; this is wrong, because it means that resizing the window also changes the amount that snowberry is visually zoomed in.
that means that on non-1080p window sizes, the 1× zoom level is not actually 1×, as its pixels are not the same size as pixels on the user's screen.
that's a bad thing, since it means that users whose screens are not simple fractions of 1080p cannot have pixel-perfect rendering.

this fixes the problem by removing references to `Engine.ScreenMatrix` / `.Width` / `.Height`.

depends on #20